### PR TITLE
Urdf collision

### DIFF
--- a/adamr2_control/config/controller.yml
+++ b/adamr2_control/config/controller.yml
@@ -16,8 +16,6 @@ adamr2:
     wheel_radius: 0.0775
     cmd_vel_timeout: 0.5
 
-    #wheel_separation_multiplier: 1.0636
-
     base_frame_id: base_footprint
     odom_frame_id: odom
 

--- a/adamr2_control/config/controller_sim.yml
+++ b/adamr2_control/config/controller_sim.yml
@@ -1,0 +1,38 @@
+adamr2:
+  joint_state_controller:
+    type: joint_state_controller/JointStateController
+    publish_rate: 50
+
+  diff_drive_controller:
+    type: "diff_drive_controller/DiffDriveController"
+    left_wheel: 'left_wheel_joint'
+    right_wheel: 'right_wheel_joint'
+    publish_rate: 50
+
+    pose_covariance_diagonal: [0.001, 0.001, 1000000.0, 1000000.0, 1000000.0, 10.0]
+    twist_covariance_diagonal: [0.001, 0.001, 1000000.0, 1000000.0, 1000000.0, 10.0]
+
+    wheel_separation: 0.413
+    wheel_radius: 0.0775
+    cmd_vel_timeout: 0.5
+
+    base_frame_id: base_footprint
+    odom_frame_id: odom
+
+    linear:
+      x:
+        has_velocity_limits: true
+        max_velocity: 1.6
+        min_velocity: -1.6
+        has_acceleration_limits: true
+        max_acceleration: 0.8
+        min_acceleration: -0.8
+      
+    angular:
+      z:
+        has_velocity_limits: true
+        max_velocity: 1.57
+        min_velocity: -1.57
+        has_acceleration_limits: true
+        max_acceleration: 1.57
+        min_acceleration: -1.57

--- a/adamr2_control/launch/adamr2_control_sim.launch
+++ b/adamr2_control/launch/adamr2_control_sim.launch
@@ -1,5 +1,5 @@
 <launch>
-  <rosparam file="$(find adamr2_control)/config/controller.yml" command="load"/>
+  <rosparam file="$(find adamr2_control)/config/controller_sim.yml" command="load"/>
 
   <group ns="adamr2">
     <node name="controller_spawner" type="spawner" pkg="controller_manager"

--- a/adamr2_description/urdf/wheel/wheel.xacro
+++ b/adamr2_description/urdf/wheel/wheel.xacro
@@ -26,9 +26,9 @@
       </inertial>
 
       <collision>
-        <origin xyz="0.0 0.0 0.0"/>
+        <origin xyz="0.0 0.0 0.0" rpy="${radians(90)} 0.0 0.0"/>
         <geometry>
-          <mesh filename="package://adamr2_description/meshes/wheel_link.STL"/>
+          <cylinder radius="0.0775" length="0.030"/>
         </geometry>
       </collision>
     </link>


### PR DESCRIPTION
ホイールの当たり判定をプリミティブ図形に置き換えたらGazeboの動作が軽くなった．問題解決である．